### PR TITLE
Allow users to launch FAHclient with a passkey

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN mkdir -p /etc/fahclient/ && \
 
 FROM debian:stable-slim
 
+ENV COMMAND_ALLOW=127.0.0.1
 ENV WEB_ALLOW=0/0
 ENV ALLOW=0/0
 ENV GPU=false

--- a/start_folding.sh
+++ b/start_folding.sh
@@ -3,6 +3,7 @@
 team="--team=${FAH_TEAM:-0}"
 user="--user=${FAH_USER:-Anonymous}"
 power="--power=${POWER:-medium}"
+command_allow="--command-allow-no-pass=${COMMAND_ALLOW:-127.0.0.1}
 web_allow="--web-allow=${WEB_ALLOW:-0/0}"
 allow="--allow=${WEB_ALLOW:-0/0}"
 gpu="--gpu=${GPU:-false}"
@@ -14,6 +15,6 @@ else
   passkey="--passkey=${FAH_PASSKEY}"
 fi
 
-cmd="/usr/bin/FAHClient ${team} ${user} ${power} ${web_allow} ${allow} ${gpu} ${smp} ${passkey}"
+cmd="/usr/bin/FAHClient ${team} ${user} ${power} ${command_allow} ${web_allow} ${allow} ${gpu} ${smp} ${passkey}"
 echo "${cmd} $@"
 exec $cmd $@

--- a/start_folding.sh
+++ b/start_folding.sh
@@ -8,6 +8,12 @@ allow="--allow=${WEB_ALLOW:-0/0}"
 gpu="--gpu=${GPU:-false}"
 smp="--smp=${SMP:-false}"
 
-cmd="/usr/bin/FAHClient ${team} ${user} ${power} ${web_allow} ${allow} ${gpu} ${smp}"
+if [[ -z "${FAH_PASSKEY}" ]]; then
+  passkey=""
+else
+  passkey="--passkey=${FAH_PASSKEY}"
+fi
+
+cmd="/usr/bin/FAHClient ${team} ${user} ${power} ${web_allow} ${allow} ${gpu} ${smp} ${passkey}"
 echo "${cmd} $@"
 exec $cmd $@


### PR DESCRIPTION
Some users may want to use a passkey, so we should allow that option